### PR TITLE
remove extern C syntax

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,6 +26,7 @@ conan_basic_setup()''')
 
     def package(self):
         self.copy("*.h", dst="include", src="luajit/src")
+        self.copy("*.hpp", dst="include", src="luajit/src")
         self.copy("*.h", dst="include", src="", excludes="luajit/*")
         self.copy("*.lib", dst="lib", keep_path=False)
         self.copy("*.dll", dst="bin", keep_path=False)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -7,7 +7,7 @@ class LuajitTestConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure(source_dir=self.conanfile_directory, build_dir="./")
+        cmake.configure()
         cmake.build()
 
     def imports(self):

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,11 +1,5 @@
 #include <cstring>
-
-extern "C" {
-    #include "lua.h"
-    #include "lualib.h"
-    #include "lauxlib.h"
-}
-
+#include "lua.hpp"
 int main(int argc, char* argv[])
 {
     lua_State * L = lua_open();


### PR DESCRIPTION
Considering this issue:  https://github.com/int010h/conan-luajit/issues/1
it seems, LuaJIT contains lua.hpp, it just needs to be copied. 
`conan create . luajit_digitalist/testing` test shows `"Hello World from LuaJIT!"`

also I had to patch build string for my (recent) version of conan to remove an error:
```
ERROR: PROJECT: Error in build() method, line 10
	cmake.configure(source_dir=self.conanfile_directory, build_dir="./")
	AttributeError: 'LuajitTestConan' object has no attribute 'conanfile_directory'
```

It would be nice if this PR worked out, because it's much easier both for setting up luajit via conan and using it with sol